### PR TITLE
Tutoriel: sauvegarde de la progression et correction des pop-ups

### DIFF
--- a/bin/evaluate_code.ml
+++ b/bin/evaluate_code.ml
@@ -62,34 +62,7 @@ let evaluate_code () =
 
   match%lwt IBuild.interactive_build ~show_move ~show_conf ~show_moves_list ~get_move init_conf with
   | IBuild.Success ->
-      let local_storage = Js.Unsafe.get Js.Unsafe.global "localStorage" in
-      Js.Unsafe.meth_call local_storage "setItem"
-        [| Js.Unsafe.inject (Js.string "tuto_completed");
-          Js.Unsafe.inject (Js.string "true") |]
-      |> ignore;
-      let doc = Dom_html.document in
-      let modal = Dom_html.createDiv doc in
-      let content = Dom_html.createDiv doc in
-      let btn = Dom_html.createButton doc in
-
-      modal##.classList##add (Js.string "win-modal");
-      content##.classList##add (Js.string "win-modal-content");
-      btn##.classList##add (Js.string "win-reset-btn");
-      content##.innerHTML := Js.string
-        "<h2 class = 'win-title'>🏆 SUCCÈS !</h2>\
-        <p class = 'win-message'>Vous avez déclenché un failwith. Félicitations ! Prêt pour la suite ?</p>";
-
-      btn##.textContent := Js.some (Js.string "Niveau Suivant >>");
-
-      btn##.onclick := Dom_html.handler (fun _ ->
-        Dom.removeChild doc##.body modal;
-        let tuto = Dom_html.getElementById "tuto-badge" in
-        if Js.Opt.test (Dom_html.CoerceTo.element tuto) then Js.Unsafe.meth_call Js.Unsafe.global "nextLevel" [||] |> ignore;
-        Js._true
-      );
-      Dom.appendChild content btn;
-      Dom.appendChild modal content;
-      Dom.appendChild doc##.body modal;
+      let () = Js.Unsafe.global##onSuccess [||] in
 
       Lwt.return 1
 

--- a/front/common.js
+++ b/front/common.js
@@ -1,0 +1,58 @@
+function openModal(modal) {
+    modal.style = 'display: flex';
+}
+
+function closeModal(modal) {
+    modal.style = 'display: none';
+}
+
+function setModalTitle(modal, title) {
+    modal.getElementsByClassName('win-title')[0].innerHTML = title;
+}
+
+function setModalMessage(modal, message) {
+    modal.getElementsByClassName('win-message')[0].innerHTML = message;
+}
+
+function addModalButton(modal, text, onClick) {
+    const btn = document.createElement('button');
+
+    btn.innerText = text;
+    btn.classList.add('win-reset-btn');
+    btn.addEventListener('click', onClick);
+
+    const content = modal.getElementsByClassName('win-modal-content')[0];
+    content.appendChild(btn);
+}
+
+function createModal(id, withCloseButton) {
+    const modal   = document.createElement('div');
+    const content = document.createElement('div');
+    const title   = document.createElement('h2');
+    const par     = document.createElement('p');
+
+    modal.id = id;
+
+    modal.classList.add('win-modal');
+    content.classList.add('win-modal-content');
+    title.classList.add('win-title');
+    par.classList.add('win-message');
+
+    if(withCloseButton) {
+        const close = document.createElement('span');
+        close.classList.add('close-btn');
+        close.addEventListener('click', (_) => closeModal(modal));
+        close.innerHTML = '&times;';
+        content.appendChild(close);
+    }
+
+    modal.appendChild(content);
+    content.appendChild(title);
+    content.appendChild(par);
+
+    modal.style = 'display: none';
+
+    document.getElementsByTagName('body')[0].appendChild(modal);
+
+    return modal;
+}

--- a/front/index.html
+++ b/front/index.html
@@ -146,6 +146,76 @@
   </script>
   
   <script>
+    function openModal(modal) {
+        modal.style = 'display: flex';
+    }
+
+    function closeModal(modal) {
+        modal.style = 'display: none';
+    }
+
+    function setModalTitle(modal, title) {
+        modal.getElementsByClassName('win-title')[0].innerHTML = title;
+    }
+
+    function setModalMessage(modal, message) {
+        modal.getElementsByClassName('win-message')[0].innerHTML = message;
+    }
+
+    function addModalButton(modal, text, onClick) {
+        let btn = document.createElement('button');
+
+        btn.innerText = text;
+        btn.classList.add('win-reset-btn');
+        btn.addEventListener('click', onClick);
+
+        let content = modal.getElementsByClassName('win-modal-content')[0];
+        content.appendChild(btn);
+    }
+
+    function createModal(id, withCloseButton) {
+        let modal   = document.createElement('div');
+        let content = document.createElement('div');
+        let title   = document.createElement('h2');
+        let par     = document.createElement('p');
+
+        modal.id = id;
+        
+        modal.classList.add('win-modal');
+        content.classList.add('win-modal-content');
+        title.classList.add('win-title');
+        par.classList.add('win-message');
+        
+        if(withCloseButton) {
+            let close = document.createElement('span');
+            close.classList.add('close-btn');
+            close.addEventListener('click', (_) => closeModal(modal));
+            close.innerHTML = '&times;';
+            content.appendChild(close);
+        }
+
+        modal.appendChild(content);
+        content.appendChild(title);
+        content.appendChild(par);
+
+        modal.style = 'display: none';
+
+        document.getElementsByTagName('body')[0].appendChild(modal);
+
+        return modal;
+    }
+
+    const successModal = createModal('success', true);
+
+    setModalTitle(successModal, "🏆 SUCCÈS");
+    setModalMessage(successModal, "Vous avez déclenché un failwith. Félicitations !");
+    addModalButton(successModal, "Ok", (_) => closeModal(successModal));
+
+    function onSuccess() {
+        openModal(successModal);
+        // no-op outside of the tutorial
+    }
+
     window.onload = async function () {
      
       // --- LOGIQUE DE JEU (DOSSIER TEST) ---

--- a/front/index.html
+++ b/front/index.html
@@ -144,67 +144,10 @@
       event.currentTarget.classList.add("active");
     }
   </script>
+
+  <script src="common.js"></script>
   
   <script>
-    function openModal(modal) {
-        modal.style = 'display: flex';
-    }
-
-    function closeModal(modal) {
-        modal.style = 'display: none';
-    }
-
-    function setModalTitle(modal, title) {
-        modal.getElementsByClassName('win-title')[0].innerHTML = title;
-    }
-
-    function setModalMessage(modal, message) {
-        modal.getElementsByClassName('win-message')[0].innerHTML = message;
-    }
-
-    function addModalButton(modal, text, onClick) {
-        let btn = document.createElement('button');
-
-        btn.innerText = text;
-        btn.classList.add('win-reset-btn');
-        btn.addEventListener('click', onClick);
-
-        let content = modal.getElementsByClassName('win-modal-content')[0];
-        content.appendChild(btn);
-    }
-
-    function createModal(id, withCloseButton) {
-        let modal   = document.createElement('div');
-        let content = document.createElement('div');
-        let title   = document.createElement('h2');
-        let par     = document.createElement('p');
-
-        modal.id = id;
-        
-        modal.classList.add('win-modal');
-        content.classList.add('win-modal-content');
-        title.classList.add('win-title');
-        par.classList.add('win-message');
-        
-        if(withCloseButton) {
-            let close = document.createElement('span');
-            close.classList.add('close-btn');
-            close.addEventListener('click', (_) => closeModal(modal));
-            close.innerHTML = '&times;';
-            content.appendChild(close);
-        }
-
-        modal.appendChild(content);
-        content.appendChild(title);
-        content.appendChild(par);
-
-        modal.style = 'display: none';
-
-        document.getElementsByTagName('body')[0].appendChild(modal);
-
-        return modal;
-    }
-
     const successModal = createModal('success', true);
 
     setModalTitle(successModal, "🏆 SUCCÈS");

--- a/front/indextuto.html
+++ b/front/indextuto.html
@@ -117,7 +117,68 @@
   </script>
   
   <script>
-    let currentLevel = 1;
+    function openModal(modal) {
+        modal.style = 'display: flex';
+    }
+
+    function closeModal(modal) {
+        modal.style = 'display: none';
+    }
+
+    function setModalTitle(modal, title) {
+        modal.getElementsByClassName('win-title')[0].innerHTML = title;
+    }
+
+    function setModalMessage(modal, message) {
+        modal.getElementsByClassName('win-message')[0].innerHTML = message;
+    }
+
+    function addModalButton(modal, text, onClick) {
+        const btn = document.createElement('button');
+
+        btn.innerText = text;
+        btn.classList.add('win-reset-btn');
+        btn.addEventListener('click', onClick);
+
+        const content = modal.getElementsByClassName('win-modal-content')[0];
+        content.appendChild(btn);
+    }
+
+    function createModal(id, withCloseButton) {
+        const modal   = document.createElement('div');
+        const content = document.createElement('div');
+        const title   = document.createElement('h2');
+        const par     = document.createElement('p');
+
+        modal.id = id;
+        
+        modal.classList.add('win-modal');
+        content.classList.add('win-modal-content');
+        title.classList.add('win-title');
+        par.classList.add('win-message');
+        
+        if(withCloseButton) {
+            const close = document.createElement('span');
+            close.classList.add('close-btn');
+            close.addEventListener('click', (_) => closeModal(modal));
+            close.innerHTML = '&times;';
+            content.appendChild(close);
+        }
+
+        modal.appendChild(content);
+        content.appendChild(title);
+        content.appendChild(par);
+
+        modal.style = 'display: none';
+
+        document.getElementsByTagName('body')[0].appendChild(modal);
+
+        return modal;
+    }
+
+    /* === Global declarations === */
+    const cavocCurrentLevelName = 'cavoc-current-level';
+    let   currentLevel = localStorage.getItem(cavocCurrentLevelName);
 
     // Valeurs par défaut si le fichier JSON est manquant ou incomplet
     const DEFAULT_CONFIG = { 
@@ -126,11 +187,38 @@
         visibility: false 
     };
 
+    // Declared here because it is required by onSuccess and nextLevel
+    const successModal = createModal('success', false);
+    const tutoEndModal = createModal('tutoEnd', false);
+
     // Fonction appelée par OCaml (explore_web.ml) lors du succès
-    window.nextLevel = function() {
+    function nextLevel() {
+        closeModal(successModal);
+
         currentLevel++;
+        localStorage.setItem(cavocCurrentLevelName, currentLevel);
+
         loadLevel(currentLevel);
-    };
+    }
+
+    // Called by OCaml (see evaluate_code.ml) after a success
+    function onSuccess() {
+        openModal(successModal);
+    }
+
+    setModalTitle(successModal, "🏆 SUCCÈS !");
+    setModalMessage(successModal, "Vous avez déclenché un failwith. Félicitations ! Prêt pour la suite ?");
+    addModalButton(successModal, "Niveau suivant >>", (_) => nextLevel());
+
+    setModalTitle(tutoEndModal, "🏆 SUCCÈS !");
+    setModalMessage(tutoEndModal, "Vous avez terminé le tutoriel. Félicitations !");
+    addModalButton(tutoEndModal, "Passer à la suite", (_) => {
+        window.location.href = "index.html";
+    });
+
+    if(currentLevel === null) {
+        currentLevel = 1;
+    }
 
     // Fonction principale pour charger un niveau
     async function loadLevel(level) {
@@ -202,8 +290,7 @@
           .catch((error) => {
              if (error.message === "Fini") {
                  // Gestion de la fin du tutoriel
-                 alert("Bravo ! Vous avez terminé tous les tutoriels disponibles !");
-                 window.location.href = "index.html"; 
+                 openModal(tutoEndModal);
              } else {
                  console.error("Erreur chargement code :", error);
              }

--- a/front/indextuto.html
+++ b/front/indextuto.html
@@ -115,67 +115,10 @@
       event.currentTarget.classList.add("active");
     }
   </script>
+
+  <script src="common.js"></script>
   
   <script>
-    function openModal(modal) {
-        modal.style = 'display: flex';
-    }
-
-    function closeModal(modal) {
-        modal.style = 'display: none';
-    }
-
-    function setModalTitle(modal, title) {
-        modal.getElementsByClassName('win-title')[0].innerHTML = title;
-    }
-
-    function setModalMessage(modal, message) {
-        modal.getElementsByClassName('win-message')[0].innerHTML = message;
-    }
-
-    function addModalButton(modal, text, onClick) {
-        const btn = document.createElement('button');
-
-        btn.innerText = text;
-        btn.classList.add('win-reset-btn');
-        btn.addEventListener('click', onClick);
-
-        const content = modal.getElementsByClassName('win-modal-content')[0];
-        content.appendChild(btn);
-    }
-
-    function createModal(id, withCloseButton) {
-        const modal   = document.createElement('div');
-        const content = document.createElement('div');
-        const title   = document.createElement('h2');
-        const par     = document.createElement('p');
-
-        modal.id = id;
-        
-        modal.classList.add('win-modal');
-        content.classList.add('win-modal-content');
-        title.classList.add('win-title');
-        par.classList.add('win-message');
-        
-        if(withCloseButton) {
-            const close = document.createElement('span');
-            close.classList.add('close-btn');
-            close.addEventListener('click', (_) => closeModal(modal));
-            close.innerHTML = '&times;';
-            content.appendChild(close);
-        }
-
-        modal.appendChild(content);
-        content.appendChild(title);
-        content.appendChild(par);
-
-        modal.style = 'display: none';
-
-        document.getElementsByTagName('body')[0].appendChild(modal);
-
-        return modal;
-    }
-
     /* === Global declarations === */
     const cavocCurrentLevelName = 'cavoc-current-level';
     let   currentLevel = localStorage.getItem(cavocCurrentLevelName);

--- a/front/indextuto.html
+++ b/front/indextuto.html
@@ -193,8 +193,6 @@
 
     // Fonction appelée par OCaml (explore_web.ml) lors du succès
     function nextLevel() {
-        closeModal(successModal);
-
         currentLevel++;
         localStorage.setItem(cavocCurrentLevelName, currentLevel);
 
@@ -208,11 +206,20 @@
 
     setModalTitle(successModal, "🏆 SUCCÈS !");
     setModalMessage(successModal, "Vous avez déclenché un failwith. Félicitations ! Prêt pour la suite ?");
-    addModalButton(successModal, "Niveau suivant >>", (_) => nextLevel());
+    addModalButton(successModal, "Niveau suivant >>", _ => {
+        nextLevel();
+        closeModal(successModal);
+    });
 
     setModalTitle(tutoEndModal, "🏆 SUCCÈS !");
     setModalMessage(tutoEndModal, "Vous avez terminé le tutoriel. Félicitations !");
-    addModalButton(tutoEndModal, "Passer à la suite", (_) => {
+    addModalButton(tutoEndModal, "Réinitialiser le tutoriel", _ => {
+        currentLevel = 0;
+
+        nextLevel();
+        closeModal(tutoEndModal);
+    });
+    addModalButton(tutoEndModal, "Passer à la suite", _ => {
         window.location.href = "index.html";
     });
 

--- a/front/win.css
+++ b/front/win.css
@@ -47,6 +47,7 @@
     border-radius: 5px;
     cursor: pointer;
     transition: background 0.3s;
+    margin: 0px 12px;
 }
 
 .win-reset-btn:hover {


### PR DESCRIPTION
Cette PR ajoute la sauvegarde de la progression dans le tutoriel, ainsi que la possibilité de réinitialiser ce dernier.

J'en ai profité pour remplacer la pop-up statique de evaluate_code.ml, qui était affiché même hors du tutoriel par différentes pop-ups adaptées à la situation dans laquelle elles s'affichent.