### PR TITLE
Add automatic documentation generation using odoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Currently, the only programming language supported is a fragment of OCaml with:
 You can build the project using ``dune build``.
 Its dependencies are ``lwt``, ``js_of_ocaml``, and ``yojson``.
 
+The code is documented using `odoc`. Documentation can be generated using
+`dune build @doc`. It can then be viewed in your web browser by accessing
+`_build/default/_doc/_html/cavoc/index.html`.
+
 ## explore-web
 
 To run it, you first need to run a simple web server via ``dune exec ./bin/server.exe``.
@@ -51,4 +55,3 @@ You can also pass the following options to ``explore``:
     This corresponds to forbidding the client to use higher-order references to store the functions provided by the module during the interaction.
   * -no-cps, Use a representation of actions as calls and returns rather than in cps style. 
     This is incompatible with the -vis option.
-

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,1 @@
+(documentation)

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,28 @@
+{1 cavoc-proto}
+
+{e CAVOC} is a  framework for building interactive models of programming languages
+based on operatioal game semantics.
+It provides the possibility to explore dynamically the semantics of a program
+module: you take the role of a client of the module,  interacting with it by
+choosing which input action to perform.
+
+This documentation describes the implementation of the prototype. If you are
+looking for installation & use instructions, please refer to the [README.md]
+file.
+
+{2 Synopsis}
+
+{3:machinelanguages Machine languages}
+
+{e CAVOC} is parametric with respect to the programming language (called
+{e machine language} in this setting) used to write the code of modules and
+clients. To create a new machine language to use {e CAVOC} on, you need to
+provide an instance of {!module-type: Lang.Interactive.LANG_WITH_INIT}.
+
+{e CAVOC} provides a functor {!module: Lang.Interactive.Make} to build such an
+instance from a lower representation, namely an instance of
+{!module-type: Lang.Language.WITHAVAL_NEG}.
+
+{2 Contents}
+
+{!modules: Lang Lts Ogs Pogs Refml Util}

--- a/lib/RefML/dune
+++ b/lib/RefML/dune
@@ -1,11 +1,12 @@
 (ocamllex lexer)
 
 (menhir
- (modules parser)
- (explain true))
+  (modules parser)
+  (explain true))
 
 (library
- (name refml)
- (preprocess
-  (pps ppx_deriving_yojson))
- (libraries lang util yojson ppx_deriving_yojson.runtime msat msat.sat msat.tseitin))
+  (public_name cavoc.refml)
+  (name refml)
+  (preprocess
+    (pps ppx_deriving_yojson))
+  (libraries lang util yojson ppx_deriving_yojson.runtime msat msat.sat msat.tseitin))

--- a/lib/lang/dune
+++ b/lib/lang/dune
@@ -1,5 +1,6 @@
 (library
- (name lang)
- (preprocess
-  (pps ppx_deriving_yojson))
- (libraries util lwt yojson ppx_deriving_yojson.runtime))
+  (public_name cavoc.lang)
+  (name lang)
+  (preprocess
+    (pps ppx_deriving_yojson))
+  (libraries util lwt yojson ppx_deriving_yojson.runtime))

--- a/lib/lts/dune
+++ b/lib/lts/dune
@@ -1,5 +1,6 @@
 (library
- (name lts)
+  (public_name cavoc.lts)
+  (name lts)
   (preprocess
-  (pps lwt_ppx ppx_deriving_yojson))
- (libraries lang util lwt yojson ppx_deriving_yojson.runtime))
+    (pps lwt_ppx ppx_deriving_yojson))
+  (libraries lang util lwt yojson ppx_deriving_yojson.runtime))

--- a/lib/ogs/dune
+++ b/lib/ogs/dune
@@ -1,5 +1,6 @@
 (library
- (name ogs)
- (preprocess
-  (pps ppx_deriving_yojson))
- (libraries lang util lts yojson ppx_deriving_yojson.runtime))
+  (public_name cavoc.ogs)
+  (name ogs)
+  (preprocess
+    (pps ppx_deriving_yojson))
+  (libraries lang util lts yojson ppx_deriving_yojson.runtime))

--- a/lib/pogs/dune
+++ b/lib/pogs/dune
@@ -1,5 +1,6 @@
 (library
- (name pogs)
- (preprocess
-  (pps ppx_deriving_yojson))
- (libraries lang util lts yojson ppx_deriving_yojson.runtime))
+  (public_name cavoc.pogs)
+  (name pogs)
+  (preprocess
+    (pps ppx_deriving_yojson))
+  (libraries lang util lts yojson ppx_deriving_yojson.runtime))

--- a/lib/util/dune
+++ b/lib/util/dune
@@ -1,5 +1,6 @@
 (library
- (name util)
- (preprocess
-  (pps lwt_ppx ppx_deriving_yojson))
- (libraries lwt yojson ppx_deriving_yojson.runtime))
+  (public_name cavoc.util)
+  (name util)
+  (preprocess
+    (pps lwt_ppx ppx_deriving_yojson))
+  (libraries lwt yojson ppx_deriving_yojson.runtime))

--- a/lib/util/monad.ml
+++ b/lib/util/monad.ml
@@ -1,6 +1,9 @@
-(*  This file contains signatures and implementation for various monads.*)
+(**
+  This module contains the signatures and implementations of monads used throughout
+  {e CAVOC}.
+ *)
 
-(** Standard signature for monads **)
+(** Standard signature for monads. *)
 module type MONAD = sig
   type 'a m
 
@@ -8,18 +11,43 @@ module type MONAD = sig
   val ( let* ) : 'a m -> ('a -> 'b m) -> 'b m
 end
 
+(** {2 Runnable monad} *)
+
+(**
+  Standard signature for evaluation monads.
+  
+  Monads implementing [RUNNABLE] are used by {!page-index.machinelanguages}
+  to encapsulate the return type of the interpreter.
+  *)
 module type RUNNABLE = sig
   include MONAD
-  type 'a result = 
-    | PropStop
-    | Continue of 'a
 
+  (**
+     Result of evaluation of an active configuration.
+   *)
+  type 'a result = 
+    | PropStop (** This means that the proponent (i.e. the module) has stopped playing. *)
+    | Continue of 'a (** The interpreter successfuly returned some configuration(s). *)
+
+  (**
+    This type encapsulates one or more {!result}.
+
+    {!page-index.machinelanguages} are responsible for choosing an appropriate
+    implementation of [RUNNABLE] and exposing its type [r] via module
+    constraints. Type [r] is then automatically propagated upwards by functors
+    tranforming machine languages.
+   *)
   type 'a r
 
   val run : 'a m -> 'a result r
   val fail : unit -> 'a m
 end
 
+(**
+  Multi-result implementation of {!module-type: RUNNABLE}.
+
+  See {!type: RUNNABLE.r} for details about type {!type: Result.r}
+  *)
 module Result = struct
   type 'a result = 
     | PropStop
@@ -28,20 +56,26 @@ module Result = struct
 
   type 'a r = 'a list
 
-  let return x =
+  let return x : 'a m =
     [ Continue x ]
 
-  let ( let* ) a f =
+  let ( let* ) (a : 'a m) (f : 'a -> 'b m) : 'b m  =
     let bs = List.map
       (function PropStop -> [ PropStop ] | Continue x -> f x) a in
     List.concat bs
 
   let run x = x
 
-  let fail () =
+  let fail () : 'a m =
     [ PropStop ]
 end
 
+
+(**
+  Single-result implementation of {!module-type: RUNNABLE}.
+
+  See {!type: RUNNABLE.r} for details about type {!type: SingleResult.r}
+  *)
 module SingleResult = struct
   type 'a result =
     | PropStop
@@ -49,16 +83,16 @@ module SingleResult = struct
   type 'a m = 'a result
   type 'a r = 'a
 
-  let return x =
+  let return x : 'a m =
     Continue x
 
-  let ( let* ) a f =
+  let ( let* ) (a : 'a m) (f : 'a -> 'b m) : 'b m =
     (function PropStop -> PropStop | Continue x -> f x) a
 
-  let run a =
+  let run a : 'a r =
     a
   
-  let fail () =
+  let fail () : 'a m =
     PropStop
 end
 
@@ -73,9 +107,10 @@ module Option = struct
   let fail () = None
 end
 
-(** A simple branching monad **)
+(** {2 Branching monad} *)
 
-(*** Signature ***)
+
+(** Standard branching monad signature. *)
 module type BRANCH = sig
   include MONAD
 
@@ -89,7 +124,7 @@ module type BRANCH = sig
   val run : 'a m -> 'a list
 end
 
-(*** List implementation of the Branching monad ***)
+(** List implementation of the Branching monad *)
 module ListB : BRANCH = struct
   type 'a m = 'a list
 
@@ -105,7 +140,7 @@ module ListB : BRANCH = struct
 end
 
 
-(*** An implementation of the Branching monad with user input to decide how to branch ***)
+(** An implementation of the Branching monad with user input to decide how to branch *)
 module UserChoose : BRANCH = struct
   type 'a m = 'a option
 
@@ -140,14 +175,14 @@ module UserChoose : BRANCH = struct
   let run = function None -> [] | Some x -> [ x ]
 end
 
-(** State monad **)
+(** {2 State monad} *)
 
-(*** Signature for the stored elements ***)
+(** Signature for the stored elements *)
 module type MEMSTATE = sig
   type t
 end
 
-(*** Signature for the State monad ***)
+(** Standard state monad signature. *)
 module type STATE = functor (State : MEMSTATE) -> sig
   type mem_state = State.t
 
@@ -158,7 +193,7 @@ module type STATE = functor (State : MEMSTATE) -> sig
   val runState : 'a m -> mem_state -> 'a * mem_state
 end
 
-(*** Standard implementation for the State monad ***)
+(** Standard implementation for the State monad *)
 module State : STATE =
 functor
   (MemState : MEMSTATE)
@@ -178,7 +213,7 @@ functor
       runState (f avalues) st'
   end
 
-(*** Signature for the combination of the Branching and State monad ***)
+(** Signature for the combination of the Branching and State monad *)
 module type BRANCH_STATE = functor (State : MEMSTATE) -> sig
   type mem_state = State.t
 
@@ -219,10 +254,9 @@ functor
       aux avalues st'
   end
 
-(** Write monad **)
-(*** Used to produce trace of actions that can be printed ***)
+(** {2 Output monad} *)
 
-(*** Signature for showable elements ***)
+(** Signature for showable elements *)
 module type SHOWABLE = sig
   type t
 
@@ -239,6 +273,11 @@ module type OUTPUT = functor (MemState : SHOWABLE) -> sig
   val get_trace : 'a m -> event list
 end
 
+(**
+  Write monad.
+
+  Used to produce a trace of actions that can be printed.
+ *)
 module Output : OUTPUT =
 functor
   (MemState : SHOWABLE)
@@ -260,7 +299,7 @@ functor
           let (y,tr')  = f x in (y, tr @ tr')
   end
 
-(*** Signature for the combination of Branching and Write monad ***)
+(** Signature for the combination of Branching and Write monad *)
 module type BRANCH_WRITE = functor (MemState : SHOWABLE) -> sig
   type trace
 
@@ -274,7 +313,7 @@ module type BRANCH_WRITE = functor (MemState : SHOWABLE) -> sig
   val get_trace : 'a m -> trace list
 end
 
-(*** Implementation for the combination of Branching and Write monad using lists ***)
+(** Implementation for the combination of Branching and Write monad using lists *)
 module ListWrite : BRANCH_WRITE =
 functor
   (MemState : SHOWABLE)
@@ -299,7 +338,7 @@ functor
       List.flatten (List.map flift expr)
   end
 
-(*** Implementation for the combination of Branching and Write monad using user input ***)
+(** Implementation for the combination of Branching and Write monad using user input *)
 module UserChooseWrite : BRANCH_WRITE =
 functor
   (MemState : SHOWABLE)


### PR DESCRIPTION
This PR adds automatic documentation generation to the project.

I started to write some documentation for the `Monads` module to
try and see what it would look like, but the documentation is far
from complete.
I also created an index page (`doc/index.mld`) which I suppose
should eventually replace `STRUCTURE.md`.